### PR TITLE
Update to linkage criterion

### DIFF
--- a/index.ipynb
+++ b/index.ipynb
@@ -84,7 +84,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Nexts, we'll use `AgglomerativeClustering` with one parameter `n_clusters=3` to run the algorithm. Not specifying a linkage function will lead to the usage of the `wald` linkage criterion.\n",
+    "Next, we'll use `AgglomerativeClustering` with one parameter `n_clusters=3` to run the algorithm. Not specifying a linkage function will lead to the usage of the `ward` linkage criterion.\n",
     "\n",
     "Run the cell below. This cell will:\n",
     "\n",


### PR DESCRIPTION
The lab refers to the linkage criterion for HAC as 'wald' and not 'ward'.

line 87: Nexts, we'll use `AgglomerativeClustering` with one parameter `n_clusters=3` to run the algorithm. Not specifying a linkage function will lead to the usage of the `wald` linkage criterion.\n